### PR TITLE
Permutation test

### DIFF
--- a/metacatalog_corr/metrics.py
+++ b/metacatalog_corr/metrics.py
@@ -39,7 +39,24 @@ def maximal_information_coef(left: np.ndarray, right: np.ndarray, **kwargs) -> f
     """
     Maximal information coefficient (MIC) for left and right array.
     """
-    mine = minepy.MINE(alpha=0.6, c=15)
+    # choose alpha depending on sample size n (speeds up mic calculation), Albanese et al. 2018, Tab. 1
+    n = len(left)
+    conditions = [
+        n < 25, 
+        25 <= n < 50, 
+        50 <= n < 250, 
+        250 <= n < 500, 
+        500 <= n < 1000, 
+        1000 <= n < 2500,
+        2500 <= n < 5000,
+        5000 <= n < 10000,
+        10000 <= n < 40000,
+        n >= 40000 
+    ]
+    choices = [.85, .8, .75, .7, .65, .6, .55, .5, .45, .4]
+    alpha = np.select(conditions, choices)
+
+    mine = minepy.MINE(alpha=alpha, c=15)
     mine.compute_score(left, right)
     corr = mine.mic()
 

--- a/metacatalog_corr/models.py
+++ b/metacatalog_corr/models.py
@@ -214,6 +214,7 @@ class CorrelationMatrix(Base):
         p_value : bool
             If True, the p-value for the metric is saved to the database.
             The p-values are calculated from permutation tests.
+            Significantly increases the calculation time.
         force_overlap : bool
             If True, the correlation metric will only be calculated
             for data of overlapping indices. If there are None,

--- a/metacatalog_corr/models.py
+++ b/metacatalog_corr/models.py
@@ -53,7 +53,7 @@ class CorrelationMetric(Base):
     @property
     def func(self):
         """
-        Load the actual function and return
+        Load the actual function and return.
         """
         mod = importlib.import_module(self.import_path)
         func = getattr(mod, self.function_name)
@@ -61,9 +61,44 @@ class CorrelationMetric(Base):
     
     def calc(self, left: np.ndarray, right: np.ndarray) -> float:
         """
-        Calculate the metric for the given data
+        Calculate the metric for the given data.
         """
         return self.func(left, right, **self.function_args)
+
+    def permutation_test(self, left: np.ndarray, right: np.ndarray, n_iter=1000, seed=None) -> float:
+        """
+        Calculate non-parametric permutation test for the given data
+        
+        Marozzi, 2004: n_iter proposals
+        
+        """
+        # calculate "true" correlation value
+        true_corr = self.func(left, right, **self.function_args)
+        
+        # Initialize list to store permuted correlation scores
+        perm_corr = []
+
+        # right array will be shuffled
+        perm_right = right
+
+        # set random seed (reproducibility master thesis: 42)
+        np.random.seed(seed)
+
+        # Initialize permutation loop:
+        for iter in range(0, n_iter):
+            # Shuffle right array:
+            perm_right = np.random.permutation(right)
+            # Compute permuted correlations and store them in perm_corr:
+            perm_corr.append(self.func(left, perm_right, **self.function_args))
+
+        # Significance: share of perm_corr which are >= true_corr (two-sided: absolute value):
+        perm_p = len(np.where(np.abs(perm_corr) >= np.abs(true_corr))[0]) / n_iter
+        
+        # lower bound for perm_p: 1/n_iter
+        if perm_p == 0:
+            perm_p = 1/n_iter
+
+        return perm_p
 
 
 class CorrelationWarning(Base):
@@ -102,6 +137,7 @@ class CorrelationMatrix(Base):
     id = sa.Column(sa.BigInteger, primary_key=True)
     metric_id = sa.Column(sa.Integer, sa.ForeignKey('correlation_metrics.id'), nullable=False)
     value = sa.Column(sa.Numeric, nullable=False)
+    p_value = sa.Column(sa.Numeric, nullable=True)
     identifier = sa.Column(sa.String(200), nullable=True)
     left_id = sa.Column(sa.Integer, nullable=False)
     right_id = sa.Column(sa.Integer, nullable=False)
@@ -129,6 +165,7 @@ class CorrelationMatrix(Base):
             identifier=None,
             if_exists='omit',
             harmonize=True,
+            p_value=True,
             force_overlap=False,
             **kwargs
         ):
@@ -174,6 +211,9 @@ class CorrelationMatrix(Base):
             indices are used for the calculation of metrics. 
             This way, the length of left and right also match.
             Defaults to True.
+        p_value : bool
+            If True, the p-value for the metric is saved to the database.
+            The p-values are calculated from permutation tests.
         force_overlap : bool
             If True, the correlation metric will only be calculated
             for data of overlapping indices. If there are None,
@@ -304,6 +344,16 @@ class CorrelationMatrix(Base):
 
                 for warn in set(warn_list):
                     matrix.add_warning(category=warn[0], message=warn[1], session=session, commit=False)
+
+            # if p_value = True: calculate p-value with permutation test
+            if p_value:
+                try:
+                    matrix.p_value = metric.permutation_test(left, right, n_iter=1000, seed=42) # set random seed: reproducibility (master thesis)
+                except Exception as e:
+                    matrix.add_warning(category=f"Permutation warning, {e.__class__.__name__}", message=str(e), session=session, commit=False)
+                    matrix.p_value = np.nan
+            else:
+                matrix.p_value=np.nan
 
         # build the matrix value
         matrix.metric_id=metric.id

--- a/metacatalog_corr/models.py
+++ b/metacatalog_corr/models.py
@@ -87,11 +87,12 @@ class CorrelationMetric(Base):
             # Compute permuted correlations and store them in perm_corr:
             perm_corr.append(self.calc(left, perm_right, **kwargs))
         # Significance: share of perm_corr which are >= true_corr (two-sided: absolute value):
-        perm_p = len(np.where(np.abs(perm_corr) >= np.abs(true_corr))[0]) / n_iter
+        # add pseudocount to avoid perm_p = 0
+        perm_p = (1 + len(np.where(np.abs(perm_corr)) >= np.abs(true_corr))[0]) / n_iter
         
         # lower bound for perm_p: 1/n_iter
-        if perm_p == 0:
-            perm_p = 1/n_iter
+        #if perm_p == 0:
+        #    perm_p = 1/n_iter
 
         return perm_p, perm_corr
 

--- a/metacatalog_corr/models.py
+++ b/metacatalog_corr/models.py
@@ -93,9 +93,9 @@ class CorrelationMetric(Base):
         if perm_p == 0:
             perm_p = 1/n_iter
 
-        return perm_p
+        return perm_p, perm_corr
 
-    def permutation_test_jsd(self, left, right):
+    def permutation_test_jsd(self, left, right, n_iter=100, seed=None):
         """
         To perform a permutation test for the information-theoretic measures Jensen-Shannon divergence
         and distance, the binned probabilites of left and right are shuffled, instead of the values 
@@ -112,7 +112,7 @@ class CorrelationMetric(Base):
         p_left = (hist_left / np.sum(hist_left))
         p_right = (hist_right / np.sum(hist_right))
         
-        return self.permutation_test(p_left, p_right, xy_probabilities=True)
+        return self.permutation_test(p_left, p_right, n_iter, seed, xy_probabilities=True)
 
 
 class CorrelationWarning(Base):
@@ -365,9 +365,9 @@ class CorrelationMatrix(Base):
                 try:
                     # jensen shannon distance and divergence: calculate binned probabilities (discretization), permute right probabilities
                     if 'js_d' in metric.symbol:
-                        matrix.p_value = metric.permutation_test_jsd(left, right, n_iter=1000, seed=42) # set random seed: reproducibility (master thesis)
+                        matrix.p_value, _ = metric.permutation_test_jsd(left, right, n_iter=100, seed=42) # set random seed: reproducibility (master thesis)
                     else:
-                        matrix.p_value = metric.permutation_test(left, right, n_iter=1000, seed=42) # set random seed: reproducibility (master thesis)
+                        matrix.p_value, _ = metric.permutation_test(left, right, n_iter=100, seed=42) # set random seed: reproducibility (master thesis)
                 except Exception as e:
                     matrix.add_warning(category=f"Permutation warning, {e.__class__.__name__}", message=str(e), session=session, commit=False)
                     matrix.p_value = np.nan

--- a/metacatalog_corr/models.py
+++ b/metacatalog_corr/models.py
@@ -90,13 +90,15 @@ class CorrelationMetric(Base):
             perm_corr.append(self.calc(left, perm_right, **kwargs))
         # Significance: share of perm_corr which are >= true_corr (two-sided: absolute value):
         # add pseudocount to avoid perm_p = 0
-        perm_p = (1 + len(np.where(np.abs(perm_corr)) >= np.abs(true_corr))[0]) / n_iter
+        perm_p = ((len(np.where(np.abs(perm_corr)  >= np.abs(true_corr))[0])) + 1) / n_iter
+
+        # pseudocount: if all perm_corr >= true_corr -> perm_p > 1 -> not possible, set perm_p to 1
+        # perm_p > 1 would also result in a complex number for the upper bound of 95% confidence interval
+        if perm_p > 1:
+            perm_p = 1
         
-        # upper bound of 95% confidence interval
+        # perm_p: upper bound of 95% confidence interval
         perm_p = perm_p + 1.96 * ((perm_p * (1 - perm_p)) / n_iter)**0.5
-        # lower bound for perm_p: 1/n_iter
-        #if perm_p == 0:
-        #    perm_p = 1/n_iter
 
         return perm_p, perm_corr
 

--- a/metacatalog_corr/models.py
+++ b/metacatalog_corr/models.py
@@ -72,6 +72,8 @@ class CorrelationMetric(Base):
         Calculate non-parametric permutation test for the given data
         
         Marozzi, 2004: n_iter proposals
+
+        returns the upper bound of the 95% confidence interval (Opdyke, 2003)
         
         """  
         # calculate "true" correlation value
@@ -90,6 +92,8 @@ class CorrelationMetric(Base):
         # add pseudocount to avoid perm_p = 0
         perm_p = (1 + len(np.where(np.abs(perm_corr)) >= np.abs(true_corr))[0]) / n_iter
         
+        # upper bound of 95% confidence interval
+        perm_p = perm_p + 1.96 * ((perm_p * (1 - perm_p)) / n_iter)**0.5
         # lower bound for perm_p: 1/n_iter
         #if perm_p == 0:
         #    perm_p = 1/n_iter


### PR DESCRIPTION
Calculation of p-values for all metrics with a permutation test.
Probabilities are calculated before the permutation test of Jensen-Shannon distance.

Upper limit of the 95% confidence interval of the calculated p-value is returned to be more conservative.